### PR TITLE
fixing timestamps

### DIFF
--- a/RFunction.R
+++ b/RFunction.R
@@ -4,6 +4,7 @@ library('foreach')
 library('sf') # maptools deprecated
 library('geosphere')
 library('suncalc')
+library("dplyr")
 
 # for now have removed pdf map, could add it again with use of MoveApps OSM mirror
 
@@ -384,7 +385,8 @@ rFunction <- function(data, window="all", upX=0, downX=0, speedvar="speed", maxs
                   if (durx>=duration & radx<=radius) #added this condition to only save rest sites of given duration (if this condition is left out also rest site with shorter duration are given back)
                   {
                     #data.resti.df <- rbind(data.resti.df,data.selx.df)
-                    ix_sel_id <- c(ix_sel_id,which(mt_time(data.selx) %in% mt_time(data.nighti)))
+                    ix_sel_id <- c(ix_sel_id,which(mt_time(data.nighti) %in% mt_time(data.selx)))
+                    
                     
                     if (window=="all")
                     {
@@ -438,6 +440,8 @@ rFunction <- function(data, window="all", upX=0, downX=0, speedvar="speed", maxs
       sf::st_transform(data_proj)
     logger.info(paste("Retransformed result to input projection:", data_proj))
   }
+  
+  result <- dplyr::arrange(result, mt_track_id(result), mt_time(result)) ## sorting timestamps
   
   return(result)
 }

--- a/appspec.json
+++ b/appspec.json
@@ -84,6 +84,9 @@
       },
 	  {
         "name": "suncalc"
+      },
+	  {
+        "name": "dplyr"
       }
     ]
   },


### PR DESCRIPTION
Hi @andreakoelzsch, ich glaube ich habe das Problem gefunden (Issue #3). So zu sagen ein Zahlendreher bzw code dreher

WAR: ix_sel_id <- c(ix_sel_id,which(mt_time(data.selx) %in% mt_time(data.nighti))) 
ix_sel_id war immer nur 1,2,3 oder so ähnlich, da es im data.selx ja weniger timestamps gibt

GEÄNDERT ZU: ix_sel_id <- c(ix_sel_id,which(mt_time(data.nighti) %in% mt_time(data.selx)))
jetzt wird die position von den timestamps von data.selx in data.nighti gesucht, ix_sel_id ist nun 538, 950, etc

Timestamps vom alten output:
   [1] "2013-08-08 16:07:34 UTC" "2013-08-08 17:09:22 UTC" "2013-08-08 17:40:20 UTC" "2013-08-09 02:26:44 UTC"
   [5] "2013-08-08 16:07:34 UTC" "2013-08-08 17:09:22 UTC" "2013-08-08 16:07:34 UTC" "2013-08-08 17:09:22 UTC"
   [9] "2013-08-08 17:40:20 UTC" "2013-08-09 02:26:44 UTC" "2013-08-09 21:15:18 UTC" "2013-08-08 16:07:34 UTC"

Timestamps von jetzigen output: 
   [1] "2013-08-11 01:35:59 UTC" "2013-08-11 10:22:21 UTC" "2013-08-11 10:53:56 UTC" "2013-08-11 18:38:00 UTC"
   [5] "2013-08-12 03:54:56 UTC" "2013-08-12 22:26:08 UTC" "2013-08-15 06:49:02 UTC" "2013-08-15 07:04:53 UTC"
   [9] "2013-08-15 15:18:51 UTC" "2013-08-15 15:50:08 UTC" "2013-08-15 16:51:30 UTC" "2013-08-16 09:50:46 UTC"
   
   Ich musste am ende von code nochmal timestamps sortieren, bin mir nicht sicher wo sie sich nochmal vermischen, habe es nicht gefunden. Aber da alle Eigenschaften von track zu stimmen scheinen, denke ich mal das es kein weiteren Fehler gibt.
   
Zum Glück hat dieser code-dreher kein Einfluss auf die Artifacts (hab zumindest keine gefunden).

Bitte überprüfen das es korrekt ist, und das die App weiterhin das macht was sie soll.